### PR TITLE
Remove temporary testing icons

### DIFF
--- a/background.js
+++ b/background.js
@@ -159,7 +159,6 @@ async function runProcessor(){
         try {
           chrome.notifications.create(undefined, {
             type: 'basic',
-            iconUrl: 'icon48.png',
             title: 'Label queued',
             message: `Order ${job.visibleOrder || ''} added`
           });

--- a/manifest.json
+++ b/manifest.json
@@ -26,13 +26,5 @@
   "action": {
     "default_title": "Label Queue",
     "default_popup": "popup.html"
-  },
-
-  /* Icons optional; keep or remove if you prefer no icon */
-  "icons": {
-    "16": "icon16.png",
-    "32": "icon32.png",
-    "48": "icon48.png",
-    "128": "icon128.png"
   }
 }


### PR DESCRIPTION
## Summary
- remove temporary icon definitions from manifest
- drop notification icon use

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b81189b2c8332bf773fffb3f1a70e