### PR TITLE
Add messaging debug wrappers and ensure background responses

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -9,6 +9,69 @@ const HH = (() => {
   };
 })();
 
+// Debug messaging helper identical to background/content versions. It patches
+// sendMessage/onMessage to log every exchange and highlight missing replies.
+function setupMessageDebug(){
+  const origSend = chrome.runtime.sendMessage.bind(chrome.runtime);
+  chrome.runtime.sendMessage = (msg, options, cb) => {
+    let opts = options;
+    let callback = cb;
+    if (typeof options === 'function') {
+      callback = options;
+      opts = undefined;
+    }
+    HH.log('sendMessage ->', msg);
+    const timer = setTimeout(() => HH.warn('sendMessage timeout', msg), 5000);
+    const wrappedCb = (...args) => {
+      clearTimeout(timer);
+      HH.log('sendMessage <- reply', msg, args);
+      if (callback) callback(...args);
+    };
+    try {
+      return opts !== undefined ? origSend(msg, opts, wrappedCb) : origSend(msg, wrappedCb);
+    } catch (e) {
+      clearTimeout(timer);
+      HH.err('sendMessage exception', String(e), msg);
+      throw e;
+    }
+  };
+
+  const origAdd = chrome.runtime.onMessage.addListener;
+  chrome.runtime.onMessage.addListener = (fn) => {
+    const wrapped = (msg, sender, sendResponse) => {
+      HH.log('onMessage <-', msg, { sender });
+      let responded = false;
+      const timer = setTimeout(() => {
+        if (!responded) HH.warn('onMessage handler timeout', msg);
+      }, 5000);
+      const wrappedSend = (...args) => {
+        responded = true;
+        clearTimeout(timer);
+        HH.log('onMessage -> reply', msg, args);
+        try { sendResponse(...args); }
+        catch (e) { HH.err('sendResponse error', String(e)); }
+      };
+      let result = false;
+      try {
+        result = fn(msg, sender, wrappedSend);
+      } catch (e) {
+        clearTimeout(timer);
+        HH.err('onMessage handler exception', String(e));
+        throw e;
+      }
+      if (result !== true) {
+        responded = true;
+        clearTimeout(timer);
+      }
+      return result;
+    };
+    origAdd.call(chrome.runtime.onMessage, wrapped);
+  };
+}
+
+// Activate messaging debugging in popup context
+setupMessageDebug();
+
 const LABELS_KEY = 'hh_labels_v1';
 const JOBS_KEY   = 'hh_jobs_v1';
 const listEl = document.getElementById('list');


### PR DESCRIPTION
## Summary
- add debug wrappers around `chrome.runtime.sendMessage` and `onMessage` to log traffic and flag timeouts
- ensure background message handler responds and stays alive to avoid closed ports
- document early message sending in content script to avoid navigation races

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689b88bbaab883329a37b2add096f41a