### PR TITLE
Avoid sendMessage timeout by triggering processor asynchronously

### DIFF
--- a/background.js
+++ b/background.js
@@ -129,7 +129,9 @@ async function enqueueJob(job){
   const jobs = await get(JOBS_KEY, []);
   jobs.push({ ...job, status: 'pending', tries: 0, nextAt: 0 });
   await set(JOBS_KEY, jobs);
-  await runProcessor(); // kick immediately
+  // Kick the processor without awaiting so we can respond to the sender
+  // immediately. Any errors are logged.
+  runProcessor().catch(e => HH.err('runProcessor enqueue error', String(e)));
 }
 
 async function pushLabel(item){


### PR DESCRIPTION
## Summary
- run background job processor asynchronously when enqueuing a job to prevent sendMessage timeouts

## Testing
- `node --check background.js content.js`


------
https://chatgpt.com/codex/tasks/task_e_689b9a92a6dc83328791a9f3921f1651