### PR TITLE
Ensure exact match for single-character OUT keywords

### DIFF
--- a/content.js
+++ b/content.js
@@ -225,7 +225,7 @@ setupMessageDebug();
     const targetRow = rows.find(r => {
       const cells = Array.from(r.querySelectorAll('td'));
       const texts = cells.map(td => (td.textContent || '').trim().toUpperCase());
-      return texts.some(t => OUT_KEYWORDS.some(k => t.includes(k)));
+      return texts.some(t => OUT_KEYWORDS.some(k => k.length === 1 ? t === k : t.includes(k)));
     });
     if (!targetRow) {
       HH.warn('no demo/out row found yet');


### PR DESCRIPTION
## Summary
- Verify `OUT_KEYWORDS` includes `'O'`
- Match single-character keywords exactly while keeping substring matching for longer keywords

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node - <<'NODE' ...`

------
https://chatgpt.com/codex/tasks/task_e_689b9ec8d0848332bd7eebf2100eff8f