### PR TITLE
Improve demo label capture and PDF handling

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -9,6 +9,7 @@
     "storage",
     "scripting",
     "tabs",
+    "webNavigation",
     "alarms",
     "notifications"
   ],


### PR DESCRIPTION
## Summary
- open and label orders via content script with event dispatch and EXPECT_PDF message
- capture PDF URLs through window.open, navigation target and tab updates with exponential backoff
- allow PDF navigation tracking by adding webNavigation permission

## Testing
- `npm test` (fails: Could not read package.json)
- `node --check background.js`
- `node --check content.js`


------
https://chatgpt.com/codex/tasks/task_e_689bc286832883328257e283ce671acd