### PR TITLE
Match shipped order when capturing return label

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -96,11 +96,11 @@ async function load() {
       return;
     }
     const ul = document.createElement('ul');
-    labels.forEach(it => {
-      const li = document.createElement('li');
-      li.textContent = `iOrder ${it.iorder}` + (it.fromOrder ? ` (from #${it.fromOrder})` : '');
-      ul.appendChild(li);
-    });
+      labels.forEach(it => {
+        const li = document.createElement('li');
+        li.textContent = `Demo Order ${it.demoOrder}` + (it.orderNumber ? ` (from #${it.orderNumber})` : '');
+        ul.appendChild(li);
+      });
     listEl.innerHTML = '';
     listEl.appendChild(ul);
   } catch (e) {


### PR DESCRIPTION
## Summary
- Match Ship It! order number when opening return label
- Store demo order numbers separately from captured order numbers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bcec926dc8332a25b197e8b84c6e5