### PR TITLE
feat: add scoped logger and debug presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,14 @@
 # HH Return Label Queue
 
-This extension uses a structured `Logger` to reduce console noise.
+This extension uses a scoped logger with namespaces and levels. Logging
+settings are stored in `chrome.storage.local` and can be changed from the
+extension's options page or by right‑clicking the extension icon and choosing a
+preset:
 
-## Debug levels
-Set the desired level in the DevTools console:
+- **Quiet** – warn/error only (default)
+- **Focus Label Debug** – enables debug logs for the `HH:label` namespace
+- **Full Trace** – trace for all namespaces with sampling & rate limiting
 
-```js
-window.HH_DEBUG_LEVEL = 'debug'; // error | warn | info | debug | trace
-```
-
-For high-volume trace sampling, choose a value between 0 and 1:
-
-```js
-window.HH_DEBUG_SAMPLING = 0.25; // 25% of debug/trace logs
-```
-
-The logger rate‑limits repeated messages and prints a `[HH][Summary]` line every 30s (and on page hide/unload) with counts of suppressed messages.
+Each log line is timestamped and structured: `YYYY-MM-DDTHH:mm:ss.SSSZ [NS]
+level message {json}`. Repeated identical messages are de‑duplicated and
+summarised periodically.

--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,8 @@
     "tabs",
     "webNavigation",
     "alarms",
-    "notifications"
+    "notifications",
+    "contextMenus"
   ],
 
   /* Host permissions: limit to your domain */
@@ -35,5 +36,7 @@
   "action": {
     "default_title": "Label Queue",
     "default_popup": "popup.html"
-  }
+  },
+
+  "options_page": "options.html"
 }

--- a/options.html
+++ b/options.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Logging Options</title>
+</head>
+<body>
+  <button id="quiet">Quiet</button>
+  <button id="focus">Focus Label Debug</button>
+  <button id="trace">Full Trace</button>
+  <script src="logger.js"></script>
+  <script src="options.js"></script>
+</body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,30 @@
+const log = createLogger('HH:options');
+
+function setPreset(preset){
+  chrome.storage.local.set(preset, () => {
+    const err = chrome.runtime.lastError;
+    if (err) log.error('setPreset error', { error: err.message });
+    else log.info('preset applied', preset);
+  });
+}
+
+document.getElementById('quiet').addEventListener('click', () => setPreset({
+  logLevel: 'warn',
+  enableNamespaces: [],
+  sampling: {},
+  rateLimit: { windowMs: 2000, maxPerWindow: 20 }
+}));
+
+document.getElementById('focus').addEventListener('click', () => setPreset({
+  logLevel: 'debug',
+  enableNamespaces: ['HH:label'],
+  sampling: {},
+  rateLimit: { windowMs: 2000, maxPerWindow: 20 }
+}));
+
+document.getElementById('trace').addEventListener('click', () => setPreset({
+  logLevel: 'trace',
+  enableNamespaces: ['HH:*'],
+  sampling: { trace: 0.2 },
+  rateLimit: { windowMs: 2000, maxPerWindow: 20 }
+}));

--- a/popup.html
+++ b/popup.html
@@ -11,6 +11,7 @@
     <small style="display:block;margin-top:8px;color:#666">
       Tip: Launch Chrome with <code>--kiosk-printing</code> to skip the print dialog.
     </small>
+    <script src="logger.js"></script>
     <script src="popup.js"></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- introduce scoped logger with namespaces, sampling, and rate limiting
- add options page and action menu presets for logging levels
- focus label flow debug logs and move queue noise to a trace-only namespace

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_689c138cb05c83329a21c6e899526085