### PR TITLE
Avoid CSP errors for javascript: links

### DIFF
--- a/content.js
+++ b/content.js
@@ -49,6 +49,10 @@ function safeClick(el, {demoBox, ordersBox}) {
   if (!within(el, ordersBox)) {
     throw new Error('SAFEGUARD: attempted click outside Orders box — forbidden');
   }
+  const href = typeof el.getAttribute === 'function' ? (el.getAttribute('href') || '') : '';
+  if (el.tagName === 'A' && href.trim().toLowerCase().startsWith('javascript:')) {
+    el.addEventListener('click', e => e.preventDefault(), { once: true, capture: true });
+  }
   el.dispatchEvent(new MouseEvent('click', {bubbles:true, cancelable:true, view:window}));
 }
 


### PR DESCRIPTION
## Summary
- prevent CSP violations by intercepting javascript: links in safeClick

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689cb5fdbc0c8332bb3a7570d4469e2d