### PR TITLE
Prevent demo script from navigating away when selecting orders

### DIFF
--- a/content.js
+++ b/content.js
@@ -382,9 +382,14 @@ chrome.runtime.onMessage.addListener((msg, sender, sendResponse) => {
     const link = row.querySelector('a[href*="iorder="]');
     const iorder = /iorder=(\d+)/i.exec(link?.href || '')?.[1] || orderNo;
     labelLog.debug('mapped to iorder', { visibleOrder: orderNo, iorder });
-    safeClick(row, ctx);
+    if (link) {
+      link.addEventListener('click', e => e.preventDefault(), { once: true });
+      safeClick(link, ctx);
+    } else {
+      safeClick(row, ctx);
+    }
     labelLog.debug('opening order row', { iorder });
-    const panel = await waitForElem(() => document.querySelector(SEL.orderPanelByNumber(orderNo)), 10000);
+    const panel = await waitForElem(() => document.querySelector(SEL.orderPanelByNumber(iorder)), 10000);
     if (!panel){ labelLog.dedup('order panel not found', { orderNo }, 'warn'); return; }
     await waitForElem(() => panel.querySelector('#Ord1, #TItems'), 10000);
 


### PR DESCRIPTION
## Summary
- prevent navigation when clicking order rows by intercepting anchor clicks
- look up order panel using the internal `iorder` value

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: repository release file not found)*

------
https://chatgpt.com/codex/tasks/task_e_689cbf6104bc8332bca66ac2c1ad7d99