### PR TITLE
Handle CSP restrictions for label links and fix notifications

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -4,7 +4,6 @@
   "version": "1.0.1",
   "manifest_version": 3,
 
-  /* Permissions: keep minimal but sufficient */
   "permissions": [
     "storage",
     "scripting",
@@ -14,8 +13,6 @@
     "notifications",
     "contextMenus"
   ],
-
-  /* Host permissions: limit to your domain */
   "host_permissions": [
     "https://www.hattorihanzoshears.com/*"
   ],
@@ -29,7 +26,6 @@
   ],
 
   "background": {
-    /* Classic service worker (not module) so we can importScripts(pdf-lib) */
     "service_worker": "background.js"
   },
 


### PR DESCRIPTION
## Summary
- Call `viewDemoLabel`/`viewReturnLabel`/`sendReturnLabel` directly instead of triggering `javascript:` URLs
- Use inline data URL for notification icon and handle notification errors
- Remove binary icon and icons entry from the manifest to keep JSON valid

## Testing
- `node --check background.js`
- `node --check content.js`
- `jq . manifest.json`


------
https://chatgpt.com/codex/tasks/task_e_689f8bd9b1208332851891642b764d68