### PR TITLE
Fix demo order row detection

### DIFF
--- a/content.js
+++ b/content.js
@@ -391,7 +391,13 @@ function waitFor(fn, timeoutMs = 10000, poll = 100) {
     let ttl = 60000, delay = 200;
     while (ttl > 0){
       const rows = Array.from(document.querySelectorAll(SEL.orderRowMatcher(orderNo)));
-      const row = rows.find(r => (r.textContent || '').includes(`#${orderNo}`));
+      const row = rows.find(r => {
+        const txt = r.textContent || '';
+        if (!txt.includes(`#${orderNo}`)) return false;
+        // Only match outbound demo rows where the status column is "O"
+        const status = (r.querySelector('td:nth-child(1)')?.textContent || '').trim().toUpperCase();
+        return status === 'O';
+      });
       if (row) return row;
       await sleep(delay);
       ttl -= delay;


### PR DESCRIPTION
## Summary
- ensure `findOrderRow` only returns demo rows (status "O") to avoid clicking shipping orders

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5f753d6cc83329cee8c6dd6f03a3b