### PR TITLE
Fix order selection to favor iOrder over visible order

### DIFF
--- a/content.js
+++ b/content.js
@@ -154,11 +154,11 @@ async function openOrderAndClickLabel(iorder, visibleOrder) {
 
   const rows = [...accordion.querySelectorAll('.rwOrdr')];
   let row = null;
-  if (visibleOrder) {
-    row = rows.find(r => (r.textContent || '').includes(`#${visibleOrder}`));
-  }
-  if (!row && iorder) {
+  if (iorder) {
     row = rows.find(r => (r.textContent || '').includes(`#${iorder}`) || r.querySelector(`a[href*="iorder=${iorder}"]`));
+  }
+  if (!row && visibleOrder) {
+    row = rows.find(r => (r.textContent || '').includes(`#${visibleOrder}`));
   }
   if (!row) throw new Error(`Order row not found for iorder=${iorder} visibleOrder=${visibleOrder}`);
 


### PR DESCRIPTION
## Summary
- prefer internal iOrder when locating and opening order rows before falling back to visible order

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a5fab774008332b8eec5e6fbb3720b