### PR TITLE
feat: wait for demo label menu

### DIFF
--- a/content.js
+++ b/content.js
@@ -207,11 +207,17 @@ async function openOrderAndClickLabel(iorder, visibleOrder) {
   let invoked = false;
   try {
     const orderBtn = panel.querySelector('.btn-group .dropdown-toggle');
+    let menuItem = null;
     if (orderBtn) {
       safeClick(orderBtn, ctx);
-      await new Promise(r => setTimeout(r, 50));
+      menuItem = await waitFor(
+        () => panel.querySelector('li[data-demoaction] a[onclick*="viewDemoLabel"]'),
+        10000,
+        200
+      ).catch(() => null);
+    } else {
+      menuItem = panel.querySelector('li[data-demoaction] a[onclick*="viewDemoLabel"]');
     }
-    const menuItem = panel.querySelector('li[data-demoaction] a[onclick*="viewDemoLabel"]');
     if (menuItem) {
       labelLog.debug('clicking View Demo Label via menu', { iorder: actualIorder });
       safeClick(menuItem, ctx);


### PR DESCRIPTION
## Summary
- wait for "View Demo Label" menu item to appear after opening order options

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6021c70608332bfcf8dc4bf78d04d