### PR TITLE
Fix logger import path in background worker

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,7 +1,7 @@
 /* background.js */
 /* global PDFLib */
 
-importScripts('logger.js');
+importScripts(chrome.runtime.getURL('logger.js'));
 const log = createLogger('HH:bg');
 const queueLog = createLogger('HH:queue');
 const labelLog = createLogger('HH:label');


### PR DESCRIPTION
## Summary
- load `logger.js` in the background service worker using `chrome.runtime.getURL`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node --check background.js`


------
https://chatgpt.com/codex/tasks/task_e_68a60594c5048332969ffad666faf248