### PR TITLE
Auto-enable DemoFix logs based on debug presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ summarised periodically.
 
 ## Demo Orders QA Checklist
 
-Enable verbose logs by appending `?demodebug=1` to the URL or running in the console:
+Verbose logs are enabled automatically when the extension's logging preset is set to **Focus Label Debug** or **Full Trace**. To force logging on a specific page, append `?demodebug=1` to the URL or run:
 
 ```js
 localStorage.setItem('DemoFixDebug','1');


### PR DESCRIPTION
## Summary
- Enable DemoFix logger whenever extension logging is in Focus Label Debug or Full Trace
- Clarify Demo Orders QA instructions about automatic logging

## Testing
- `npm test` *(fails: ENOENT could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a62438dad88332b8b34b8839c3dbb8