### PR TITLE
fix: handle demo label links without data attributes

### DIFF
--- a/content.js
+++ b/content.js
@@ -211,12 +211,20 @@ async function openOrderAndClickLabel(iorder, visibleOrder) {
     if (orderBtn) {
       safeClick(orderBtn, ctx);
       menuItem = await waitFor(
-        () => panel.querySelector('li[data-demoaction] a[onclick*="viewDemoLabel"], li[data-demoaction] a[href*="viewDemoLabel"]'),
+        () => panel.querySelector(
+          'li[data-demoaction] a[onclick*="viewDemoLabel"], '
+          + 'li[data-demoaction] a[href*="viewDemoLabel"], '
+          + 'a[onclick*="viewDemoLabel"], a[href*="viewDemoLabel"]'
+        ),
         10000,
         200
       ).catch(() => null);
     } else {
-      menuItem = panel.querySelector('li[data-demoaction] a[onclick*="viewDemoLabel"], li[data-demoaction] a[href*="viewDemoLabel"]');
+      menuItem = panel.querySelector(
+        'li[data-demoaction] a[onclick*="viewDemoLabel"], '
+        + 'li[data-demoaction] a[href*="viewDemoLabel"], '
+        + 'a[onclick*="viewDemoLabel"], a[href*="viewDemoLabel"]'
+      );
     }
     if (menuItem) {
       labelLog.debug('clicking View Demo Label via menu', { iorder: actualIorder });

--- a/src/features/demoOrders/ensureDemoLabel.js
+++ b/src/features/demoOrders/ensureDemoLabel.js
@@ -119,10 +119,21 @@ function callViewDemoLabel(orderNum, details){
       const btn = details.querySelector('.btn-group .dropdown-toggle');
       if (btn) {
         btn.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, view: window }));
-        const menuItem = details.querySelector('li[data-demoaction] a[onclick*="viewDemoLabel"], li[data-demoaction] a[href*="viewDemoLabel"]');
+        const menuItem = details.querySelector(
+          'li[data-demoaction] a[onclick*="viewDemoLabel"], '
+          + 'li[data-demoaction] a[href*="viewDemoLabel"], '
+          + 'a[onclick*="viewDemoLabel"], a[href*="viewDemoLabel"]'
+        );
         if (menuItem) {
           DemoLog.info('Clicking View Demo Label via menu');
           menuItem.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, view: window }));
+          const href = (menuItem.getAttribute('href') || '').toLowerCase();
+          const hasOnClick = menuItem.hasAttribute('onclick');
+          if ((href.startsWith('javascript:') || !hasOnClick) && typeof window.viewDemoLabel === 'function') {
+            try { window.viewDemoLabel(); } catch (e) {
+              DemoLog.warn('manual viewDemoLabel failed', e);
+            }
+          }
           viaMenu = true;
         }
       }


### PR DESCRIPTION
## Summary
- broaden selectors to locate `View Demo Label` links lacking `data-demoaction`
- manually invoke `viewDemoLabel` when menu item uses `javascript:` URLs or lacks `onclick`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6266d4a008332bef67faac0b7709a