### PR TITLE
fix: open demo label reliably

### DIFF
--- a/content.js
+++ b/content.js
@@ -228,14 +228,32 @@ async function openOrderAndClickLabel(iorder, visibleOrder) {
     }
     if (menuItem) {
       labelLog.debug('clicking View Demo Label via menu', { iorder: actualIorder });
-      const href = (menuItem.getAttribute('href') || '').toLowerCase();
+      let href = (menuItem.getAttribute('href') || '').trim().toLowerCase();
       const hasOnClick = menuItem.hasAttribute('onclick');
+      if (href === 'javascript:') {
+        menuItem.setAttribute('href', '#');
+        href = '#';
+        if (hasOnClick) {
+          const onclick = menuItem.getAttribute('onclick') || '';
+          if (!/return false;?$/i.test(onclick)) {
+            menuItem.setAttribute('onclick', onclick.replace(/;?$/, '; return false;'));
+          }
+        }
+      }
       safeClick(menuItem, ctx);
-      // If the menu item relies on a javascript: URL or lacks an onclick
-      // handler, our safeClick can suppress the site's built‑in behavior.
-      // Manually invoke viewDemoLabel so the PDF opens reliably.
-      if ((href.startsWith('javascript:') || !hasOnClick) && typeof window.viewDemoLabel === 'function') {
-        try { window.viewDemoLabel(); } catch (e) {
+      // If the menu item lacks an onclick handler our safeClick can suppress
+      // the site's built‑in behavior. Manually invoke viewDemoLabel so the
+      // PDF opens reliably in a new tab.
+      if (!hasOnClick && typeof window.viewDemoLabel === 'function') {
+        try {
+          const before = location.href;
+          window.viewDemoLabel();
+          const after = location.href;
+          if (after !== before && after.includes('shippingLabelDemo.cfm')) {
+            window.open(after, '_blank', 'noopener');
+            try { history.replaceState(null, '', before); } catch {}
+          }
+        } catch (e) {
           labelLog.error('manual viewDemoLabel failed', String(e));
         }
       }


### PR DESCRIPTION
## Summary
- normalize demo label links so inline handlers fire
- fall back to manual viewDemoLabel and open PDF in new tab

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*


------
https://chatgpt.com/codex/tasks/task_e_68a62bacfeac833290f9f360bfdd8279