### PR TITLE
Capture same-tab PDF navigation

### DIFF
--- a/background.js
+++ b/background.js
@@ -202,6 +202,17 @@ chrome.webNavigation.onCreatedNavigationTarget.addListener(({tabId, sourceTabId,
   }
 });
 
+// Capture same-tab navigations to PDFs that may not trigger tabs.onUpdated
+chrome.webNavigation.onCommitted.addListener(({tabId, frameId, url}) => {
+  if (frameId !== 0) return; // ignore subframes
+  handlePdfCandidate(tabId, url, 'webNav.onCommitted');
+});
+
+chrome.webNavigation.onCompleted.addListener(({tabId, frameId, url}) => {
+  if (frameId !== 0) return; // ignore subframes
+  handlePdfCandidate(tabId, url, 'webNav.onCompleted');
+});
+
 chrome.tabs.onUpdated.addListener((tabId, changeInfo) => {
   const info = expecting.get(tabId);
   if (!info) return;


### PR DESCRIPTION
## Summary
- handle PDFs opened in the same tab by listening to `webNavigation.onCommitted` and `onCompleted`
- update PDF candidate logic to use these events, preventing label processing from stalling when links don't spawn new tabs

## Testing
- `node --check background.js`
- `node --check content.js`


------
https://chatgpt.com/codex/tasks/task_e_68a62eb42d6c8332b5b3fc8387e621e3