### PR TITLE
Fix demo label link when href uses javascript scheme

### DIFF
--- a/content.js
+++ b/content.js
@@ -230,7 +230,7 @@ async function openOrderAndClickLabel(iorder, visibleOrder) {
       labelLog.debug('clicking View Demo Label via menu', { iorder: actualIorder });
       let href = (menuItem.getAttribute('href') || '').trim().toLowerCase();
       const hasOnClick = menuItem.hasAttribute('onclick');
-      if (href === 'javascript:') {
+      if (href.startsWith('javascript:')) {
         menuItem.setAttribute('href', '#');
         href = '#';
         if (hasOnClick) {
@@ -249,7 +249,7 @@ async function openOrderAndClickLabel(iorder, visibleOrder) {
           const before = location.href;
           window.viewDemoLabel();
           const after = location.href;
-          if (after !== before && after.includes('shippingLabelDemo.cfm')) {
+          if (after !== before && after.toLowerCase().includes('shippinglabeldemo.cfm')) {
             window.open(after, '_blank', 'noopener');
             try { history.replaceState(null, '', before); } catch {}
           }

--- a/src/features/demoOrders/ensureDemoLabel.js
+++ b/src/features/demoOrders/ensureDemoLabel.js
@@ -128,7 +128,7 @@ function callViewDemoLabel(orderNum, details){
           DemoLog.info('Clicking View Demo Label via menu');
           let href = (menuItem.getAttribute('href') || '').trim().toLowerCase();
           const hasOnClick = menuItem.hasAttribute('onclick');
-          if (href === 'javascript:') {
+          if (href.startsWith('javascript:')) {
             menuItem.setAttribute('href', '#');
             href = '#';
             if (hasOnClick) {
@@ -146,7 +146,7 @@ function callViewDemoLabel(orderNum, details){
               const before = location.href;
               window.viewDemoLabel();
               const after = location.href;
-              if (after !== before && after.includes('shippingLabelDemo.cfm')) {
+              if (after !== before && after.toLowerCase().includes('shippinglabeldemo.cfm')) {
                 window.open(after, '_blank', 'noopener');
                 try { history.replaceState(null, '', before); } catch {}
               }


### PR DESCRIPTION
## Summary
- Treat any demo label menu link starting with `javascript:` as a script URL so the click isn't suppressed
- Detect `shippinglabeldemo.cfm` case-insensitively to ensure new tab opens for demo labels

## Testing
- `npm test` *(fails: enoent could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6309dfce88332a3ab22331ad40cab