### PR TITLE
Restore native click behavior for Ship It detection

### DIFF
--- a/content.js
+++ b/content.js
@@ -17,13 +17,10 @@ const SEL = {
   orderPanelByNumber: (n) => `#O${n}`,
 };
 
-// DO NOT USE: element.click() — always use safeClick
+// Preserve the native click method so extension code can invoke it safely
+// without modifying global element behavior. Avoid calling `element.click()`
+// directly elsewhere; use safeClick() with proper safeguards instead.
 const _click = HTMLElement.prototype.click;
-Object.defineProperty(HTMLElement.prototype, 'click', {
-  value: function() {
-    throw new Error('Direct element.click() is disabled; use safeClick() inside Orders only.');
-  }
-});
 
 function findDemoBox(){
   return Array.from(document.querySelectorAll('h4'))
@@ -54,7 +51,7 @@ function safeClick(el, {demoBox, ordersBox}) {
       e.stopImmediatePropagation();
     }, { once: true, capture: true });
   }
-  el.dispatchEvent(new MouseEvent('click', { bubbles: true, cancelable: true, view: window }));
+  _click.call(el);
 }
 
 


### PR DESCRIPTION
## Summary
- Preserve the page's native `click` handler instead of overriding it
- Use the saved native click inside `safeClick` to avoid interfering with site scripts

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68a766c0516483329e3cea892be28752