### PR TITLE
fix: correct tsconfig outDir

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,7 +5,8 @@
     "strict": true,
     "esModuleInterop": true,
     "forceConsistentCasingInFileNames": true,
-    "outDir": "src"
+    "rootDir": "src",
+    "outDir": "dist"
   },
   "include": ["src/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- fix TypeScript config: set `rootDir` to `src` and `outDir` to `dist`
- this allows `npx tsc --noEmit` to find inputs instead of excluding them

## Testing
- `npm test`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_68a76da70cc88332beba15a692508619