### PR TITLE
Avoid capturing placeholder label URLs

### DIFF
--- a/background.js
+++ b/background.js
@@ -218,6 +218,12 @@ chrome.webNavigation.onCreatedNavigationTarget.addListener(({tabId, sourceTabId,
   expecting.set(tabId, info);
   info.tabIds.add(tabId);
   if (looksLikePdf(url)) {
+    // Some endpoints first open a placeholder URL like
+    // `shippingLabelDemo.cfm?batchNum=` and then redirect to
+    // the final URL containing the generated batch number.
+    // Skip resolving in this case so that later navigation events
+    // can capture the final URL with the batch number included.
+    if (/[?&]batchnum=$/i.test(url)) return;
     labelLog.debug('PDF captured via: onCreatedNavigationTarget', { url, iorder: info?.iorder || null });
     resolvePdfForTab(sourceTabId, url);
   }


### PR DESCRIPTION
## Summary
- Skip resolving PDFs on `onCreatedNavigationTarget` when the captured URL ends with an empty `batchNum` parameter so later events can record the final label URL

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a77b05bfb0833288ad7afcbfaba1dc